### PR TITLE
JBR-10106 BackbufferScreenshoter test to work on Windows

### DIFF
--- a/tests/BackbufferScreenshoter.java
+++ b/tests/BackbufferScreenshoter.java
@@ -18,7 +18,7 @@
 /*
  * @test
  * @summary Verifies Screenshoter.getWindowBackbufferArea()
- * @run main/othervm -Dswing.bufferPerWindow=true BackbufferScreenshoter
+ * @run main/othervm -Dswing.bufferPerWindow=true -Dsun.java2d.uiScale.enabled=false BackbufferScreenshoter
  * @run main/othervm -Dswing.bufferPerWindow=false BackbufferScreenshoter
  */
 
@@ -206,10 +206,9 @@ public class BackbufferScreenshoter {
             frame.setSize(WIDTH, HEIGHT);
             frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
             frame.getContentPane().setBackground(Color.GREEN);
-            frame.setVisible(true);
         });
 
-        robot.waitForIdle();;
+        robot.waitForIdle();
         robot.delay(1000);
 
         try {


### PR DESCRIPTION
`swing.bufferPerWindow` is force-disabled on Windows (see `SunGraphicsEnvironment`) by JBR itself as long as `sun.java2d.uiScale.enabled` is `true`. So  to make the test work on Windows as well as on other platforms I'm changing `sun.java2d.uiScale.enabled` to `false`.

The change in `testServiceUnavailable()` is unrelated to the issue, but makes that part of the test verify what it actually claims to verify.