### PR TITLE
Update GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifact
-        uses: actions/github-script@v7.0.1
+        uses: actions/github-script@v9.0.0
         with:
           script: |
             var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
@@ -32,7 +32,7 @@ jobs:
       - name: Unzip artifact
         run: unzip process.zip
       - name: Comment on PR
-        uses: actions/github-script@v7.0.1
+        uses: actions/github-script@v9.0.0
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/process-pr.yml
+++ b/.github/workflows/process-pr.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v7.0.1
       - name: Setup Java JDK
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@v5.7.0
         with:
           distribution: temurin
           java-version: 21
@@ -30,7 +30,7 @@ jobs:
           exit $EXIT_CODE
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: process
           path: artifact/

--- a/.github/workflows/update-api.yml
+++ b/.github/workflows/update-api.yml
@@ -38,11 +38,11 @@ jobs:
       API_DIFF: ${{steps.build.outputs.API_DIFF}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v7.0.1
         with:
           ssh-key: ${{secrets.PUSH_KEY}}
       - name: Setup Java JDK
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@v5.7.0
         with:
           distribution: temurin
           java-version: 21
@@ -77,7 +77,7 @@ jobs:
           echo "JAVADOC=${INPUT_JAVADOC:-"true"}" >> "$GITHUB_OUTPUT"
       - name: Upload artifact jars
         if: ${{steps.build.outputs.ARTIFACTS}}
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: jars
           path: |
@@ -109,11 +109,11 @@ jobs:
     if: needs.build.outputs.RELEASE && github.ref_name == 'main'
     steps:
       - name: Download artifact jars
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v8.0.1
         with:
           name: jars
       - name: Create release
-        uses: actions/github-script@v7.0.1
+        uses: actions/github-script@v9.0.0
         env:
           API_VERSION: ${{needs.build.outputs.API_VERSION}}
           API_DIFF: ${{needs.build.outputs.API_DIFF}}
@@ -178,7 +178,7 @@ jobs:
     if: needs.build.outputs.JAVADOC && github.ref_name == 'main'
     steps:
       - name: Download artifact jars
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v8.0.1
         with:
           name: jars
       - name: Unzip Javadoc jar
@@ -186,10 +186,10 @@ jobs:
           API_VERSION: ${{needs.build.outputs.API_VERSION}}
         run: unzip jbr-api-${API_VERSION}-javadoc.jar -d javadoc
       - name: Configure Pages
-        uses: actions/configure-pages@v4.0.0
+        uses: actions/configure-pages@v6.0.0
       - name: Upload Javadoc Pages artifact
-        uses: actions/upload-pages-artifact@v3.0.1
+        uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: 'javadoc'
       - name: Deploy Javadoc to Pages
-        uses: actions/deploy-pages@v4.0.4
+        uses: actions/deploy-pages@v5.0.0


### PR DESCRIPTION
checkout 4.1.1 -> 7.0.1, setup-java 4.1.0 -> 5.7.0, upload-artifact 4.3.1 -> 7.0.1, download-artifact 4.1.7 -> 8.0.1, github-script 7.0.1 -> 9.0.0, configure-pages 4.0.0 -> 6.0.0, upload-pages-artifact 3.0.1 -> 5.0.0, deploy-pages 4.0.4 -> 5.0.0.